### PR TITLE
Misc fixes

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--format progress

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development do
 end
 
 group :test do
-  gem 'rspec', '~> 2.6.0'
+  gem 'rspec', '~> 2.99'
   gem 'mocha'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,20 @@
 source "http://rubygems.org"
 
 # Specify your gem's dependencies in guard-puppet.gemspec
-gemspec
+gemspec development_group: :gem_build_tools
 
-require 'rbconfig'
-if RbConfig::CONFIG['host_os'] =~ /linux/
-  gem 'libnotify'
+group :development do
+
+  require 'rbconfig'
+  if RbConfig::CONFIG['host_os'] =~ /linux/
+    gem 'libnotify'
+  end
+end
+
+group :test do
+  gem 'rspec', '~> 2.6.0'
+  gem 'mocha'
+end
+
+group :gem_build_tools do
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source "http://rubygems.org"
 gemspec development_group: :gem_build_tools
 
 group :development do
+  gem 'guard', '~> 2.12'
+  gem 'guard-rspec', '~> 4.5'
 
   require 'rbconfig'
   if RbConfig::CONFIG['host_os'] =~ /linux/

--- a/Guardfile
+++ b/Guardfile
@@ -1,9 +1,8 @@
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 
-guard 'rspec', :version => 2 do
+guard 'rspec', cmd: 'bundle exec rspec' do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { "spec" }
 end
-

--- a/Guardfile
+++ b/Guardfile
@@ -1,8 +1,28 @@
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 
-guard 'rspec', cmd: 'bundle exec rspec' do
-  watch(%r{^spec/.+_spec\.rb$})
-  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
-  watch('spec/spec_helper.rb')  { "spec" }
+# Note: The cmd option is now required due to the increasing number of ways
+#       rspec may be run, below are examples of the most common uses.
+#  * bundler: 'bundle exec rspec'
+#  * bundler binstubs: 'bin/rspec'
+#  * spring: 'bin/rspec' (This will use spring if running and you have
+#                          installed the spring binstubs per the docs)
+#  * zeus: 'zeus rspec' (requires the server to be started separately)
+#  * 'just' rspec: 'rspec'
+
+guard :rspec, cmd: "bundle exec rspec" do
+  require "guard/rspec/dsl"
+  dsl = Guard::RSpec::Dsl.new(self)
+
+  # Feel free to open issues for suggestions and improvements
+
+  # RSpec files
+  rspec = dsl.rspec
+  watch(rspec.spec_helper) { rspec.spec_dir }
+  watch(rspec.spec_support) { rspec.spec_dir }
+  watch(rspec.spec_files)
+
+  # Ruby files
+  ruby = dsl.ruby
+  dsl.watch_spec_files_for(ruby.lib_files)
 end

--- a/guard-puppet.gemspec
+++ b/guard-puppet.gemspec
@@ -20,7 +20,4 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'guard'
   s.add_dependency 'puppet'
-
-  s.add_development_dependency 'rspec', '~> 2.6.0'
-  s.add_development_dependency 'mocha'
 end

--- a/guard-puppet.gemspec
+++ b/guard-puppet.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'guard', '~> 2.12'
+  s.add_dependency 'guard-compat', '~> 1.2'
   s.add_dependency 'puppet', '~> 4.1'
 end

--- a/guard-puppet.gemspec
+++ b/guard-puppet.gemspec
@@ -11,8 +11,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Reapply Puppet configs automatically using Guard.}
   s.description = %q{Reapply Puppet configs automatically using Guard.}
 
-  s.rubyforge_project = "guard-puppet"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }

--- a/guard-puppet.gemspec
+++ b/guard-puppet.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.homepage    = "https://github.com/guard/guard-puppet"
   s.summary     = %q{Reapply Puppet configs automatically using Guard.}
-  s.description = %q{Reapply Puppet configs automatically using Guard.}
+  s.description = %q{Guard plugin to reapply Puppet configurations.}
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/guard-puppet.gemspec
+++ b/guard-puppet.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.version     = Guard::PuppetVersion::VERSION
   s.authors     = ["John Bintz"]
   s.email       = ["john@coswellproductions.com"]
+  s.license     = "MIT"
   s.homepage    = "https://github.com/guard/guard-puppet"
   s.summary     = %q{Reapply Puppet configs automatically using Guard.}
   s.description = %q{Reapply Puppet configs automatically using Guard.}

--- a/guard-puppet.gemspec
+++ b/guard-puppet.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version     = Guard::PuppetVersion::VERSION
   s.authors     = ["John Bintz"]
   s.email       = ["john@coswellproductions.com"]
-  s.homepage    = ""
+  s.homepage    = "https://github.com/guard/guard-puppet"
   s.summary     = %q{Reapply Puppet configs automatically using Guard.}
   s.description = %q{Reapply Puppet configs automatically using Guard.}
 

--- a/guard-puppet.gemspec
+++ b/guard-puppet.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'guard'
-  s.add_dependency 'puppet'
+  s.add_dependency 'guard', '~> 2.12'
+  s.add_dependency 'puppet', '~> 4.1'
 end

--- a/lib/guard/puppet.rb
+++ b/lib/guard/puppet.rb
@@ -1,12 +1,12 @@
-require 'guard/guard'
+require 'guard/compat/plugin'
 
-module ::Guard
-  class Puppet < ::Guard::Guard
+module Guard
+  class Puppet < Plugin
     class << self
       attr_accessor :is_wrapping_exit
     end
 
-    def initialize(watchers = [], options = {})
+    def initialize(options = {})
       super
       @options = options
 

--- a/lib/guard/puppet/runner.rb
+++ b/lib/guard/puppet/runner.rb
@@ -21,6 +21,12 @@ module Guard
 
         begin
           maybe_bundle_with_env do
+            # TODO: hack, untested, needed to avoid:
+            #
+            #"Error: Could not initialize global default settings:
+            #  Attempting to initialize global default settings more than once!"
+            ::Puppet.settings.send(:clear_everything_for_tests)
+
             ::Puppet::Util::CommandLine.new('puppet', command_line_params).execute
           end
           0

--- a/lib/guard/puppet/runner.rb
+++ b/lib/guard/puppet/runner.rb
@@ -50,7 +50,7 @@ module Guard
       private
       def maybe_bundle_with_env(&block)
         if defined?(::Bundler)
-          Bundler.with_clean_env(&block)
+          ::Bundler.with_clean_env(&block)
         else
           yield
         end

--- a/spec/lib/guard/puppet/runner_spec.rb
+++ b/spec/lib/guard/puppet/runner_spec.rb
@@ -32,15 +32,36 @@ describe Guard::Puppet::Runner do
   end
 
   describe '#run' do
-    before do
-      ::Puppet::Util::CommandLine.expects(:new).raises(SystemExit.new(return_value))
-    end
-
     context 'returns a non-zero value' do
+      before do
+        ::Puppet::Util::CommandLine.expects(:new).raises(SystemExit.new(return_value))
+      end
+
       let(:return_value) { 10 }
 
       it 'should return the result of an exit call' do
         runner.run.should == return_value
+      end
+    end
+
+    context 'when bundler is used' do
+      before do
+        module ::Guard
+          class Bundler
+            def self.with_clean_env
+              fail "Called with_clean_env on Guard::Bundler instead of Bundler"
+            end
+          end
+        end
+      end
+
+      it 'uses a clean env' do
+        ran = false
+        ::Bundler.stubs(:with_clean_env).with() do
+          ran = true
+        end
+        runner.run
+        ran.should == true
       end
     end
 

--- a/spec/lib/guard/puppet_spec.rb
+++ b/spec/lib/guard/puppet_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
+require 'guard/compat/test/helper'
 require 'guard/puppet'
-require 'guard/ui'
-require 'guard/notifier'
 
 describe Guard::Puppet do
   let(:guard) { described_class.new }
@@ -21,7 +20,7 @@ describe Guard::Puppet do
       it 'should run Puppet on start' do
         Guard::Puppet.any_instance.expects(:run_all)
 
-        described_class.new([], { :run_on_start => true })
+        described_class.new(:run_on_start => true)
       end
     end
   end


### PR DESCRIPTION
- update to RSpec 2.99
- lock dependencies to newer/working versions of Guard and deps
- fix gemspec errors/warnings
- use `Guard::Compat` for backward and future/forward compatibility
- update `Guard::RSpec` config
- reset global Puppet state to allow subsequent runs (on Puppet >= 3)
- avoid conflict between `Bundler` and `Guard::Bundler`
